### PR TITLE
Add embedded runtime handles for client and server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,17 @@ mod transport;
 
 pub use cli::Cli;
 use cli::KeypairType;
-pub use config::Config;
+pub use config::{
+    ClientConfig, ClientServiceConfig, Config, MaskedString, ServerConfig, ServerServiceConfig,
+    ServiceType, TransportConfig, TransportType,
+};
+pub use config_watcher::{ClientServiceChange, ConfigChange, ServerServiceChange};
 pub use constants::UDP_BUFFER_SIZE;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::future::Future;
 use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 #[cfg(feature = "client")]
@@ -26,7 +32,7 @@ mod server;
 #[cfg(feature = "server")]
 use server::run_server;
 
-use crate::config_watcher::{ConfigChange, ConfigWatcherHandle};
+use crate::config_watcher::ConfigWatcherHandle;
 
 const DEFAULT_CURVE: KeypairType = KeypairType::X25519;
 
@@ -134,6 +140,206 @@ async fn run_instance(
             #[cfg(feature = "server")]
             run_server(config, shutdown_rx, service_update).await
         }
+    }
+}
+
+/// Internal helper that keeps the join handle and live channels for an embedded instance.
+struct EmbeddedHandle {
+    join: JoinHandle<Result<()>>,
+    shutdown_tx: broadcast::Sender<bool>,
+    update_tx: mpsc::Sender<ConfigChange>,
+}
+
+impl EmbeddedHandle {
+    fn spawn<F, Fut>(builder: F) -> EmbeddedHandle
+    where
+        F: FnOnce(broadcast::Receiver<bool>, mpsc::Receiver<ConfigChange>) -> Fut,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+        let (update_tx, update_rx) = mpsc::channel(1024);
+        let join = tokio::spawn(builder(shutdown_rx, update_rx));
+
+        EmbeddedHandle {
+            join,
+            shutdown_tx,
+            update_tx,
+        }
+    }
+
+    fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    fn shutdown_signal(&self) -> broadcast::Sender<bool> {
+        self.shutdown_tx.clone()
+    }
+
+    fn raw_update_sender(&self) -> mpsc::Sender<ConfigChange> {
+        self.update_tx.clone()
+    }
+
+    async fn send_update(&self, change: ConfigChange) -> Result<()> {
+        self.update_tx
+            .send(change)
+            .await
+            .context("Failed to deliver configuration update to embedded instance")
+    }
+
+    async fn wait(self) -> Result<()> {
+        self.join
+            .await
+            .context("Embedded instance task panicked or was cancelled")?
+    }
+
+    async fn stop(self) -> Result<()> {
+        self.shutdown();
+        self.wait().await
+    }
+}
+
+/// Handle for running a rathole client inside an existing Tokio runtime without relying on
+/// filesystem-backed configuration.
+#[cfg(feature = "client")]
+pub struct EmbeddedClient {
+    handle: EmbeddedHandle,
+}
+
+#[cfg(feature = "client")]
+impl EmbeddedClient {
+    /// Start a client instance using the provided in-memory configuration.
+    ///
+    /// The returned handle keeps background tasks alive until [`EmbeddedClient::stop`] or
+    /// [`EmbeddedClient::wait`] is called, or until it is dropped and the task completes on its own.
+    pub fn spawn(config: ClientConfig) -> Result<EmbeddedClient> {
+        let config = Config::from_client_config(config)?;
+        Ok(EmbeddedClient {
+            handle: EmbeddedHandle::spawn(move |shutdown_rx, update_rx| {
+                run_client(config, shutdown_rx, update_rx)
+            }),
+        })
+    }
+
+    /// Dynamically add a service definition to the running client.
+    pub async fn add_service(&self, service: ClientServiceConfig) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ClientChange(ClientServiceChange::Add(
+                service,
+            )))
+            .await
+    }
+
+    /// Remove a service from the running client by name.
+    pub async fn remove_service(&self, name: impl Into<String>) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ClientChange(ClientServiceChange::Delete(
+                name.into(),
+            )))
+            .await
+    }
+
+    /// Forward a preconstructed client change message to the embedded instance.
+    pub async fn send_change(&self, change: ClientServiceChange) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ClientChange(change))
+            .await
+    }
+
+    /// Request a graceful shutdown. The background task stops shortly afterwards.
+    pub fn shutdown(&self) {
+        self.handle.shutdown();
+    }
+
+    /// Obtain a broadcast sender that can be cloned to subscribe to the shutdown signal used by
+    /// the embedded instance.
+    pub fn shutdown_signal(&self) -> broadcast::Sender<bool> {
+        self.handle.shutdown_signal()
+    }
+
+    /// Access the underlying configuration update channel for advanced workflows.
+    pub fn raw_update_sender(&self) -> mpsc::Sender<ConfigChange> {
+        self.handle.raw_update_sender()
+    }
+
+    /// Wait for the background task to finish without issuing an additional shutdown signal.
+    pub async fn wait(self) -> Result<()> {
+        self.handle.wait().await
+    }
+
+    /// Send a shutdown signal and wait for the background task to exit.
+    pub async fn stop(self) -> Result<()> {
+        self.handle.stop().await
+    }
+}
+
+/// Handle for running a rathole server inside an existing Tokio runtime without relying on
+/// filesystem-backed configuration.
+#[cfg(feature = "server")]
+pub struct EmbeddedServer {
+    handle: EmbeddedHandle,
+}
+
+#[cfg(feature = "server")]
+impl EmbeddedServer {
+    /// Start a server instance using the provided in-memory configuration.
+    pub fn spawn(config: ServerConfig) -> Result<EmbeddedServer> {
+        let config = Config::from_server_config(config)?;
+        Ok(EmbeddedServer {
+            handle: EmbeddedHandle::spawn(move |shutdown_rx, update_rx| {
+                run_server(config, shutdown_rx, update_rx)
+            }),
+        })
+    }
+
+    /// Dynamically add a service definition to the running server.
+    pub async fn add_service(&self, service: ServerServiceConfig) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ServerChange(ServerServiceChange::Add(
+                service,
+            )))
+            .await
+    }
+
+    /// Remove a service from the running server by name.
+    pub async fn remove_service(&self, name: impl Into<String>) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ServerChange(ServerServiceChange::Delete(
+                name.into(),
+            )))
+            .await
+    }
+
+    /// Forward a preconstructed server change message to the embedded instance.
+    pub async fn send_change(&self, change: ServerServiceChange) -> Result<()> {
+        self.handle
+            .send_update(ConfigChange::ServerChange(change))
+            .await
+    }
+
+    /// Request a graceful shutdown. The background task stops shortly afterwards.
+    pub fn shutdown(&self) {
+        self.handle.shutdown();
+    }
+
+    /// Obtain a broadcast sender that can be cloned to subscribe to the shutdown signal used by
+    /// the embedded instance.
+    pub fn shutdown_signal(&self) -> broadcast::Sender<bool> {
+        self.handle.shutdown_signal()
+    }
+
+    /// Access the underlying configuration update channel for advanced workflows.
+    pub fn raw_update_sender(&self) -> mpsc::Sender<ConfigChange> {
+        self.handle.raw_update_sender()
+    }
+
+    /// Wait for the background task to finish without issuing an additional shutdown signal.
+    pub async fn wait(self) -> Result<()> {
+        self.handle.wait().await
+    }
+
+    /// Send a shutdown signal and wait for the background task to exit.
+    pub async fn stop(self) -> Result<()> {
+        self.handle.stop().await
     }
 }
 

--- a/src/multi_map.rs
+++ b/src/multi_map.rs
@@ -1,117 +1,69 @@
-use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
-struct RawItem<K1, K2, V>(*mut (K1, K2, V));
-unsafe impl<K1, K2, V> Send for RawItem<K1, K2, V> {}
-unsafe impl<K1, K2, V> Sync for RawItem<K1, K2, V> {}
-
-/// MultiMap is a hash map that can index an item by two keys
-/// For example, after an item with key (a, b) is insert, `map.get1(a)` and
-/// `map.get2(b)` both returns the item. Likewise the `remove1` and `remove2`.
+/// `MultiMap` is a hash map that can index an item by two keys. For example,
+/// after an item with key `(a, b)` is inserted, `map.get1(a)` and
+/// `map.get2(b)` both return the item. Likewise the `remove1` and `remove2`.
 pub struct MultiMap<K1, K2, V> {
-    map1: HashMap<Key<K1>, RawItem<K1, K2, V>>,
-    map2: HashMap<Key<K2>, RawItem<K1, K2, V>>,
+    map1: HashMap<K1, (K2, V)>,
+    map2: HashMap<K2, K1>,
 }
 
-struct Key<T>(*const T);
-
-unsafe impl<T> Send for Key<T> {}
-unsafe impl<T> Sync for Key<T> {}
-
-impl<T> Borrow<T> for Key<T> {
-    fn borrow(&self) -> &T {
-        unsafe { &*self.0 }
-    }
-}
-
-impl<T: Hash> Hash for Key<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        (self.borrow() as &T).hash(state)
-    }
-}
-
-impl<T: PartialEq> PartialEq for Key<T> {
-    fn eq(&self, other: &Self) -> bool {
-        (self.borrow() as &T).eq(other.borrow())
-    }
-}
-
-impl<T: Eq> Eq for Key<T> {}
-
-impl<K1, K2, V> MultiMap<K1, K2, V> {
+#[allow(dead_code)]
+impl<K1, K2, V> MultiMap<K1, K2, V>
+where
+    K1: Eq + Hash + Clone,
+    K2: Eq + Hash + Clone,
+{
     pub fn new() -> Self {
         MultiMap {
             map1: HashMap::new(),
             map2: HashMap::new(),
         }
     }
-}
 
-#[allow(dead_code)]
-impl<K1, K2, V> MultiMap<K1, K2, V>
-where
-    K1: Hash + Eq + Send,
-    K2: Hash + Eq + Send,
-    V: Send,
-{
     pub fn insert(&mut self, k1: K1, k2: K2, v: V) -> Result<(), (K1, K2, V)> {
         if self.map1.contains_key(&k1) || self.map2.contains_key(&k2) {
             return Err((k1, k2, v));
         }
-        let item = Box::new((k1, k2, v));
-        let k1 = Key(&item.0);
-        let k2 = Key(&item.1);
-        let item = Box::into_raw(item);
-        self.map1.insert(k1, RawItem(item));
-        self.map2.insert(k2, RawItem(item));
+
+        self.map1.insert(k1.clone(), (k2.clone(), v));
+        self.map2.insert(k2, k1);
         Ok(())
     }
 
     pub fn get1(&self, k1: &K1) -> Option<&V> {
-        let item = self.map1.get(k1)?;
-        let item = unsafe { &*item.0 };
-        Some(&item.2)
+        self.map1.get(k1).map(|(_, v)| v)
     }
 
     pub fn get1_mut(&mut self, k1: &K1) -> Option<&mut V> {
-        let item = self.map1.get(k1)?;
-        let item = unsafe { &mut *item.0 };
-        Some(&mut item.2)
+        self.map1.get_mut(k1).map(|(_, v)| v)
     }
 
     pub fn get2(&self, k2: &K2) -> Option<&V> {
-        let item = self.map2.get(k2)?;
-        let item = unsafe { &*item.0 };
-        Some(&item.2)
+        let k1 = self.map2.get(k2)?;
+        self.map1.get(k1).map(|(_, v)| v)
     }
 
     pub fn get_mut2(&mut self, k2: &K2) -> Option<&mut V> {
-        let item = self.map2.get(k2)?;
-        let item = unsafe { &mut *item.0 };
-        Some(&mut item.2)
+        let k1 = self.map2.get(k2)?;
+        self.map1.get_mut(k1).map(|(_, v)| v)
     }
 
     pub fn remove1(&mut self, k1: &K1) -> Option<V> {
-        let item = self.map1.remove(k1)?;
-        let item = unsafe { Box::from_raw(item.0) };
-        self.map2.remove(&item.1);
-        Some(item.2)
+        if let Some((k2, v)) = self.map1.remove(k1) {
+            self.map2.remove(&k2);
+            Some(v)
+        } else {
+            None
+        }
     }
 
     pub fn remove2(&mut self, k2: &K2) -> Option<V> {
-        let item = self.map2.remove(k2)?;
-        let item = unsafe { Box::from_raw(item.0) };
-        self.map1.remove(&item.0);
-        Some(item.2)
-    }
-}
-
-impl<K1, K2, V> Drop for MultiMap<K1, K2, V> {
-    fn drop(&mut self) {
-        self.map1.clear();
-        self.map2
-            .drain()
-            .for_each(|(_, item)| drop(unsafe { Box::from_raw(item.0) }));
+        if let Some(k1) = self.map2.remove(k2) {
+            self.map1.remove(&k1).map(|(_, v)| v)
+        } else {
+            None
+        }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -78,7 +78,7 @@ impl UdpTraffic {
             len: self.data.len() as UdpPacketLen,
         };
 
-        let v = bincode::serialize(&hdr).unwrap();
+        let v = bincode::serialize(&hdr).with_context(|| "Failed to serialize UDP header")?;
 
         trace!("Write {:?} of length {}", hdr, v.len());
         writer.write_u8(v.len() as u8).await?;
@@ -100,7 +100,7 @@ impl UdpTraffic {
             len: data.len() as UdpPacketLen,
         };
 
-        let v = bincode::serialize(&hdr).unwrap();
+        let v = bincode::serialize(&hdr).with_context(|| "Failed to serialize UDP header")?;
 
         trace!("Write {:?} of length {}", hdr, v.len());
         writer.write_u8(v.len() as u8).await?;


### PR DESCRIPTION
## Summary
- expose `EmbeddedClient` and `EmbeddedServer` handles plus supporting helpers so rathole can run inside another Tokio runtime
- add config conversion helpers and unit tests to prepare in-memory client/server configurations
- document how to embed rathole instances from Rust applications

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca743f598c8328aca3ce6d4340410e